### PR TITLE
Add apipath arg and some tests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,5 +24,5 @@
 
 #### Purpose
 
-#### Known Compatablity Issues
+#### Known Compatibility Issues
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache:
 install:
 - bundle install
 rvm:
-- 1.9.3
 - 2.0
 - 2.1
 - 2.2
@@ -26,7 +25,6 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 1.9.3
     rvm: 2.0
     rvm: 2.1
     rvm: 2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
 - 2.0
 - 2.1
 - 2.2
+- 2.3.0
 notifications:
   email:
     recipients:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Changed
 - update check-graylog2-alive.rb to accept an `--apipath` argument to specify the path of the transport api
 - update -alive lifecycle check because there are now multiple valid lifecyle states
-- update sensu-plugin dep to '~> 1.2'
+- drop ruby 1.9.3 support
+- update sensu-plugin dep to '1.4.4'
 - add some tests, this pulled in webmock to mock restclient calls
 - update readme
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
+- update check-graylog2-alive.rb to accept an `--apipath` argument to specify the path of the transport api
+- update -alive lifecycle check because there are now multiple valid lifecyle states
+- update sensu-plugin dep to '~> 1.2'
+- add some tests, this pulled in webmock to mock restclient calls
+- update readme
 
 ## [0.1.0] - 2016-01-29
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 - update check-graylog2-alive.rb to accept an `--apipath` argument to specify the path of the transport api
 - update -alive lifecycle check because there are now multiple valid lifecyle states
 - drop ruby 1.9.3 support
-- update sensu-plugin dep to '1.4.4'
+- update sensu-plugin dep to '~> 1.2'
 - add some tests, this pulled in webmock to mock restclient calls
 - update readme
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Dependency Status](https://gemnasium.com/sensu-plugins/sensu-plugins-graylog.svg)](https://gemnasium.com/sensu-plugins/sensu-plugins-graylog)
 
 ## Functionality
+This plugin provides availability monitoring and metrics collection for the [Graylog](https://www.graylog.org/) log management system.
 
 ## Files
  * bin/check-graylog2-alive.rb
@@ -20,3 +21,6 @@
 [Installation and Setup](http://sensu-plugins.io/docs/installation_instructions.html)
 
 ## Notes
+- If you want a limited access user for monitoring purposes please see the [Graylog FAQ](http://docs.graylog.org/en/latest/pages/faq.html#how-can-i-create-a-restricted-user-to-check-internal-graylog-metrics-in-my-monitoring-system+)
+- Users may further obfuscate their credentials by creating an [Access Token](http://docs.graylog.org/en/latest/pages/configuration/rest_api.html?highlight=access%20tokens#creating-and-using-access-token) to use instead of their normal login credentials.
+  - Note that only an admin may create a token by default.  If you want to have a dedicated monitoring user with an access token you will need to create them as a Admin user, create the token, then change the user to the monitoring specific role. You can change the default behavior by granting `users:tokencreate`, `users:tokenlist`, and `users:tokenremove` to a role and adding that role to the monitoring user.

--- a/sensu-plugins-graylog.gemspec
+++ b/sensu-plugins-graylog.gemspec
@@ -48,5 +48,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake',                      '~> 10.0'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
   s.add_development_dependency 'yard',                      '~> 0.8'
-  s.add_development_dependency 'webmock',                   '~> 2.3'
+  s.add_development_dependency 'webmock',                   '2.2.0'
 end

--- a/sensu-plugins-graylog.gemspec
+++ b/sensu-plugins-graylog.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsGraylog::Version::VER_STRING
 
-  s.add_runtime_dependency 'sensu-plugin',   '1.2.0'
+  s.add_runtime_dependency 'sensu-plugin',   '~> 1.2'
   s.add_runtime_dependency 'rest-client',    '1.8.0'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
@@ -48,4 +48,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake',                      '~> 10.0'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
   s.add_development_dependency 'yard',                      '~> 0.8'
+  s.add_development_dependency 'webmock',                   '~> 2.3'
 end

--- a/sensu-plugins-graylog.gemspec
+++ b/sensu-plugins-graylog.gemspec
@@ -30,13 +30,13 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 1.9.3'
+  s.required_ruby_version  = '>= 2.0.0'
   # s.signing_key            = File.expand_path(pvt_key) if $PROGRAM_NAME =~ /gem\z/
   s.summary                = 'Sensu plugins for graylog'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsGraylog::Version::VER_STRING
 
-  s.add_runtime_dependency 'sensu-plugin',   '~> 1.2'
+  s.add_runtime_dependency 'sensu-plugin',   '1.4.4'
   s.add_runtime_dependency 'rest-client',    '1.8.0'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
@@ -48,5 +48,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake',                      '~> 10.0'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
   s.add_development_dependency 'yard',                      '~> 0.8'
-  s.add_development_dependency 'webmock',                   '2.2.0'
+  s.add_development_dependency 'webmock',                   '~> 2.3'
 end

--- a/sensu-plugins-graylog.gemspec
+++ b/sensu-plugins-graylog.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsGraylog::Version::VER_STRING
 
-  s.add_runtime_dependency 'sensu-plugin',   '1.4.4'
+  s.add_runtime_dependency 'sensu-plugin',   '~> 1.2'
   s.add_runtime_dependency 'rest-client',    '1.8.0'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'

--- a/test/check-graylog2-alive_spec.rb
+++ b/test/check-graylog2-alive_spec.rb
@@ -1,0 +1,77 @@
+require_relative './spec_helper.rb'
+require_relative '../bin/check-graylog2-alive.rb'
+
+describe 'CheckGraylog2Alive', '#run' do
+  before(:all) do
+    CheckGraylog2Alive.class_variable_set(:@@autorun, nil)
+  end
+
+  it 'accepts config' do
+    args = %w(--username foo --password bar)
+    check = CheckGraylog2Alive.new(args)
+    expect(check.config[:password]).to eq 'bar'
+  end
+
+  it 'returns ok' do
+    stub_request(:get, 'http://localhost:12900/system')
+      .with(basic_auth: %w(foo bar))
+      .to_return(
+        status: 200,
+        headers: {
+          'Content-Type' => 'application/json'
+        },
+        body: {
+          'lifecycle' => 'running',
+          'is_processing' => true,
+          'lb_status' => 'alive'
+        }.to_json
+      )
+    args = %w(--username foo --password bar --host localhost --port 12900)
+
+    check = CheckGraylog2Alive.new(args)
+    expect(check).to receive(:ok).with('Graylog2 server is: running/true/alive').and_raise(SystemExit)
+    expect { check.run }.to raise_error(SystemExit)
+  end
+
+  it 'returns critical' do
+    stub_request(:get, 'http://localhost:12900/system')
+      .with(basic_auth: %w(foo bar))
+      .to_return(
+        status: 200,
+        headers: {
+          'Content-Type' => 'application/json'
+        },
+        body: {
+          'lifecycle' => 'busticado',
+          'is_processing' => true,
+          'lb_status' => 'dead'
+        }.to_json
+      )
+    args = %w(--username foo --password bar --host localhost --port 12900)
+
+    check = CheckGraylog2Alive.new(args)
+    expect(check).to receive(:critical).with('Graylog2 server is responding but not healthy: busticado/true/dead').and_raise(SystemExit)
+    expect { check.run }.to raise_error(SystemExit)
+  end
+
+  it 'uses apipath' do
+    stub_request(:get, 'http://localhost:12900/test/system')
+      .with(basic_auth: %w(foo bar))
+      .to_return(
+        status: 200,
+        headers: {
+          'Content-Type' => 'application/json'
+        },
+        body: {
+          'lifecycle' => 'running',
+          'is_processing' => true,
+          'lb_status' => 'alive'
+        }.to_json
+      )
+    args = %w(--username foo --password bar --host localhost --port 12900 --apipath /test)
+
+    check = CheckGraylog2Alive.new(args)
+    expect(check).to receive(:ok).with('Graylog2 server is: running/true/alive').and_raise(SystemExit)
+    expect { check.run }.to raise_error(SystemExit)
+  end
+end

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -1,2 +1,3 @@
+require 'webmock/rspec'
 require 'codeclimate-test-reporter'
 CodeClimate::TestReporter.start


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** No.

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose
This adds an `--apipath` argument to allow one to specify the path of the
transport API when it shares the same port as web services.  This path also
adds some tests since there were not any.

#### Known Compatibility Issues
None known
