### PR TITLE
python2ruby and more tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ mkmf.log
 .DS_Store
 .idea/*
 *.gem
+.ruby-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 - update sensu-plugin dep to '~> 1.2'
 - add some tests, this pulled in webmock to mock restclient calls
 - update readme
+- check-graylog-buffers
+  - port python to ruby
+  - py file is now a binstub for rb file
+  - add version support for pre/post 2.1.0 buffer metrics
+  - add apipath support
+  - add tests
 
 ## [0.1.0] - 2016-01-29
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
   - add version support for pre/post 2.1.0 buffer metrics
   - add apipath support
   - add tests
+- metics-graylog
+  - port python to ruby
+  - py file is now a binstub for rb file
+  - add --all flag for more stats (still some work to do here)
+  - add apipath support
+  - add tests
+
+
 
 ## [0.1.0] - 2016-01-29
 ### Added

--- a/bin/check-graylog-buffers.py
+++ b/bin/check-graylog-buffers.py
@@ -1,56 +1,9 @@
 #!/usr/bin/env python
 
-import urllib2
-import json
+import os
 import sys
-import getopt
-import socket
 
-def main(argv):
-    host = socket.getfqdn()
-    user = "graylog2"
-    password = "mypass"
-    port = "12900"
-    warnThreshold = 80.0
-    critThreshold = 90.0
-    try:
-        opts, args = getopt.getopt(argv, "h:u:p:P:w:c:", ["host=","user=","pass=","port=", "warn=", "crit="])
-    except getopt.GetoptError:
-        print 'flag error'
-        sys.exit(2)
-    for opt, arg in opts:
-        if opt in ("-h", "--host"):
-            host = arg
-        elif opt in ("-u", "--user"):
-            user = arg
-        elif opt in ("-p", "--pass"):
-            password = arg
-        elif opt in ("-P", "--port"):
-            port = arg
-        elif opt in ("-w", "--warn"):
-            warnThreshold = float(arg)
-        elif opt in ("-c", "--crit"):
-            critThreshold = float(arg)
 
-    # do stuff
-    passman = urllib2.HTTPPasswordMgrWithDefaultRealm()
-    passman.add_password(None, 'http://'+ host + ':' + port + '/system/buffers', user, password)
-    authhandler = urllib2.HTTPBasicAuthHandler(passman)
-    opener = urllib2.build_opener(authhandler)
-    urllib2.install_opener(opener)
-    
-    pagehandle = urllib2.urlopen('http://'+ host + ':' + port + '/system/buffers')
-    data = json.load(pagehandle)
-
-    if data['buffers']['process']['utilization_percent'] >= warnThreshold:
-        print 'WARNING: process buffer utilization is %.2f%%, threshold is %.2f%%' % (data['buffers']['process']['utilization_percent'], warnThreshold)
-        sys.exit(1)
-    elif data['buffers']['process']['utilization_percent'] >= critThreshold:
-        print 'CRITICAL: process buffer utilization is %.2f%%, threshold is %.2f%%' % (data['buffers']['process']['utilization_percent'], critThreshold)
-        sys.exit(2)
-    else:
-        print 'OK: process buffer utilization is %.2f%%' % data['buffers']['process']['utilization_percent']
-        sys.exit(0)
-
-if __name__ == "__main__":
-    main(sys.argv[1:])
+script = os.path.splitext(os.path.abspath( __file__ ))[0]
+print script
+os.execv(script + '.rb', sys.argv)

--- a/bin/check-graylog-buffers.rb
+++ b/bin/check-graylog-buffers.rb
@@ -96,7 +96,7 @@ class CheckGraylogBuffers < Sensu::Plugin::Check::CLI
     if !postdata
       JSON.parse(resource.get)
     else
-      JSON.parse(resource.post(postdata.to_json, {content_type: :json, accept: :json}))
+      JSON.parse(resource.post(postdata.to_json, content_type: :json, accept: :json))
     end
   rescue Errno::ECONNREFUSED => e
     critical e.message

--- a/bin/check-graylog-buffers.rb
+++ b/bin/check-graylog-buffers.rb
@@ -96,7 +96,7 @@ class CheckGraylogBuffers < Sensu::Plugin::Check::CLI
     if !postdata
       JSON.parse(resource.get)
     else
-      JSON.parse(resource.post(postdata.to_json))
+      JSON.parse(resource.post(postdata.to_json, {content_type: :json, accept: :json}))
     end
   rescue Errno::ECONNREFUSED => e
     critical e.message

--- a/bin/check-graylog-buffers.rb
+++ b/bin/check-graylog-buffers.rb
@@ -1,6 +1,161 @@
-#!/usr/bin/env ruby
+#! /usr/bin/env ruby
+#  encoding: UTF-8
+#   check-graylog-buffers.rb
+#
+# DESCRIPTION:
+#   This plugin checks the the status of the Graylog2 buffers using the
+#   REST API normally available on port 12900
+#
+# OUTPUT:
+#   plain text
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#   gem: json
+#   gem: rest-client
+#
+# USAGE:
+#   ./check-graylog-buffers.rb -u admin -p 12345
+#
+# NOTES:
+#   This plugin requires a username and password with permission to access
+#   the /system API call in the Graylog2 server. A basic non-admin, reader
+#   only account will do.
+#
+# LICENSE:
+#   nathan hruby <nhruby@gmail.com>
+#   SugarCRM
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
 
-bin_dir = File.expand_path(File.dirname(__FILE__))
-shell_script_path = File.join(bin_dir, File.basename($PROGRAM_NAME, '.rb') + '.py')
+require 'sensu-plugin/check/cli'
+require 'json'
+require 'rest-client'
 
-exec shell_script_path, *ARGV
+class CheckGraylogBuffers < Sensu::Plugin::Check::CLI
+  option :host,
+         description: 'Graylog host',
+         short: '-h',
+         long: '--host HOST',
+         default: 'localhost'
+
+  option :username,
+         description: 'Graylog username',
+         short: '-u',
+         long: '--username USERNAME',
+         default: 'admin',
+         required: true
+
+  option :password,
+         description: 'Graylog password',
+         short: '-p',
+         long: '--password PASSWORD',
+         required: true
+
+  option :port,
+         description: 'Graylog API port',
+         short: '-P',
+         long: '--port PORT',
+         default: '12900'
+
+  option :apipath,
+         description: 'Graylog API path prefix',
+         short: '-a',
+         long: '--apipath /api',
+         default: ''
+
+  option :warn,
+         short: '-w WARNING',
+         long: '--warning',
+         proc: proc(&:to_f),
+         default: 80
+
+  option :crit,
+         short: '-c CRITICAL',
+         long: '--critical',
+         proc: proc(&:to_f),
+         default: 90
+
+  def run
+    version = acquire_version
+    if Gem::Version.new(version) < Gem::Version.new('2.1.0')
+      check_pre_210_buffers
+    else
+      check_210_buffers
+    end
+  rescue => e
+    unknown e.message
+  end
+
+  def call_api(path, postdata = nil)
+    resource = RestClient::Resource.new "http://#{config[:host]}:#{config[:port]}#{config[:apipath]}#{path}", config[:username], config[:password]
+    if !postdata
+      JSON.parse(resource.get)
+    else
+      JSON.parse(resource.post(postdata.to_json))
+    end
+  rescue Errno::ECONNREFUSED => e
+    critical e.message
+  end
+
+  def acquire_version
+    ret = call_api('/system')
+    ret['version'].split('+')[0]
+  end
+
+  # https://github.com/Graylog2/graylog2-server/commit/0bd45c69f65011b50cb1e101c4a9c2eac97c0266
+  def check_pre_210_buffers
+    ret = call_api('/system/buffers')
+    utilization = ret['buffers']['process']['utilization_percent'].to_f
+    if utilization >= config[:crit]
+      critical format('process buffer utilization is %.2f%%, threshold is %.2f%%', utilization, config[:crit])
+    elsif utilization >= config[:warn]
+      warn format('process buffer utilization is %.2f%%, threshold is %.2f%%', utilization, config[:warn])
+    else
+      ok format('process buffer utilization is %.2f%%', utilization)
+    end
+  end
+
+  def check_210_buffers
+    postdata = {
+      'metrics' => [
+        'org.graylog2.buffers.input.usage',
+        'org.graylog2.buffers.input.size',
+        'org.graylog2.buffers.process.usage',
+        'org.graylog2.buffers.process.size',
+        'org.graylog2.buffers.output.usage',
+        'org.graylog2.buffers.output.size'
+      ]
+    }
+    ret = call_api('/system/metrics/multiple', postdata)
+
+    if ret['total'] != 6
+      unkown format('API responded with incorrect number of metrics, got %d expected 6', ret['total'])
+    end
+
+    metric_pct = {}
+    %w(input process output).each do |m|
+      begin
+        usage = ret['metrics'].find { |x| x['full_name'] == "org.graylog2.buffers.#{m}.usage" }
+        size = ret['metrics'].find { |x| x['full_name'] == "org.graylog2.buffers.#{m}.size" }
+        metric_pct[m] = (usage['metric']['value'].to_f / size['metric']['value'].to_f) * 100.0
+      rescue ZeroDivisionError
+        metric_pct[m] = 0.0
+      end
+    end
+
+    message = format('buffer utilization is %.2f%%/%.2f%%/%.2f%%', metric_pct['input'], metric_pct['process'], metric_pct['output'])
+    metric_pct.each do |m, p|
+      if p >= config[:crit]
+        critical format('%s buffer exceeds %.2f%%, %s', m, config[:crit], message)
+      elsif p >= config[:warn]
+        warn format('%s buffer exceeds %.2f%%, %s', m, config[:warn], message)
+      end
+    end
+    ok message
+  end
+end

--- a/bin/metrics-graylog.py
+++ b/bin/metrics-graylog.py
@@ -1,45 +1,9 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
-import urllib2
-import json
+import os
 import sys
-import getopt
-import socket
-import time
 
-def main(argv):
-    host = socket.getfqdn()
-    user = "graylog2"
-    password = "mypass"
-    port = "12900"
-    try:
-        opts, args = getopt.getopt(argv, "h:u:p:P:", ["host=","user=","pass=","port="])
-    except getopt.GetoptError:
-        print 'flag error'
-        sys.exit(2)
-    for opt, arg in opts:
-        if opt in ("-h", "--host"):
-            host = arg
-        elif opt in ("-u", "--user"):
-            user = arg
-        elif opt in ("-p", "--pass"):
-            password = arg
-        elif opt in ("-P", "--port"):
-            port = arg
 
-    # do stuff
-    passman = urllib2.HTTPPasswordMgrWithDefaultRealm()
-    passman.add_password(None, 'http://'+ host + ':' + port + '/system/metrics', user, password)
-    authhandler = urllib2.HTTPBasicAuthHandler(passman)
-    opener = urllib2.build_opener(authhandler)
-    urllib2.install_opener(opener)
-    
-    pagehandle = urllib2.urlopen('http://'+ host + ':' + port + '/system/metrics')
-    data = json.load(pagehandle)
-
-    print 'graylog.%s.graylog.kafkajournal.uncommittedMessages %d %d\n' % (host, data['gauges']['org.graylog2.shared.journal.KafkaJournal.uncommittedMessages']['value'], int(time.time()))
-    print 'graylog.%s.graylog.kafkajournal.unflushedMessages %d %d\n' % (host, data['gauges']['org.graylog2.shared.journal.KafkaJournal.unflushedMessages']['value'], int(time.time()))
-    sys.exit(0)
-
-if __name__ == "__main__":
-    main(sys.argv[1:])
+script = os.path.splitext(os.path.abspath( __file__ ))[0]
+print script
+os.execv(script + '.rb', sys.argv)

--- a/bin/metrics-graylog.rb
+++ b/bin/metrics-graylog.rb
@@ -110,6 +110,9 @@ class MetricsGraylog < Sensu::Plugin::Metric::CLI::Graphite
     # some-hostname-here.graylog.gauges.org.graylog2.shared.journal.KafkaJournal.writtenMessages 123 1489185301
     %w( gauges counters ).each do |type|
       data[type].each do |k, v|
+        # XXX: nrh: this is a random array but I have no idea what it supposed to
+        # contain
+        next if k == 'jvm.threads.deadlocks'
         output format('%s %2f %d', "#{config[:scheme]}.#{type}.#{k}", v['value'].to_f, timestamp)
       end
     end

--- a/bin/metrics-graylog.rb
+++ b/bin/metrics-graylog.rb
@@ -1,6 +1,127 @@
-#!/usr/bin/env ruby
+#! /usr/bin/env ruby
+#
+#   metrics-graylog.rb
+#
+# DESCRIPTION:
+#
+# OUTPUT:
+#   metric data
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#   gem: rest-client
+#   gem: json
+#
+# USAGE:
+#   metrics-graylog.rb -u user -p passwd
+#
+# NOTES:
+#   Without --all, this script returns two metrics, as the original version of
+#   this script did:
+#
+#         graylog metric metric name                             ->             sensu metric name
+#   org.graylog2.shared.journal.KafkaJournal.uncommittedMessages -> graylog.HOST.graylog.kafkajournal.uncommittedMessages
+#   org.graylog2.shared.journal.KafkaJournal.unflushedMessages   -> graylog.HOST.graylog.kafkajournal.unflushedMessages
+#
+# LICENSE:
+#   nathan hruby <nhruby@gmail.com
+#   SugarCRM
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
 
-bin_dir = File.expand_path(File.dirname(__FILE__))
-shell_script_path = File.join(bin_dir, File.basename($PROGRAM_NAME, '.rb') + '.py')
+require 'sensu-plugin/metric/cli'
+require 'json'
+require 'rest-client'
 
-exec shell_script_path, *ARGV
+class MetricsGraylog < Sensu::Plugin::Metric::CLI::Graphite
+  option :host,
+         description: 'Graylog host',
+         short: '-h',
+         long: '--host HOST',
+         default: 'localhost'
+
+  option :username,
+         description: 'Graylog username',
+         short: '-u',
+         long: '--username USERNAME',
+         default: 'admin',
+         required: true
+
+  option :password,
+         description: 'Graylog password',
+         short: '-p',
+         long: '--password PASSWORD',
+         required: true
+
+  option :port,
+         description: 'Graylog API port',
+         short: '-P',
+         long: '--port PORT',
+         default: '12900'
+
+  option :apipath,
+         description: 'Graylog API path prefix',
+         short: '-a',
+         long: '--apipath /api',
+         default: ''
+
+  option :scheme,
+         description: 'All metric naming scheme',
+         long: '--scheme SCHEME',
+         short: '-s SCHEME',
+         default: "#{Socket.gethostname}.graylog"
+
+  option :all,
+         description: 'Get all metrics',
+         long: '--all',
+         boolean: true,
+         default: false
+
+  def run
+    if config[:all]
+      all_output
+    else
+      original_output
+    end
+    ok
+  rescue => e
+    unknown e.message
+  end
+
+  def acquire_stats
+    resource = RestClient::Resource.new "http://#{config[:host]}:#{config[:port]}#{config[:apipath]}/system/metrics", config[:username], config[:password]
+    JSON.parse(resource.get)
+  rescue Errno::ECONNREFUSED => e
+    critical e.message
+  end
+
+  # XXX: only doing counters and guages since they map nicely to line data
+  # format.  Skipping meters, histograms, and timers till I can figure out
+  # sensible representation.  I don't want to throw bad data in and then have
+  # to maintain it forever.
+  def all_output
+    data = acquire_stats
+    timestamp = Time.now.to_i
+    # sample line
+    # some-hostname-here.graylog.gauges.org.graylog2.shared.journal.KafkaJournal.writtenMessages 123 1489185301
+    %w( gauges counters ).each do |type|
+      data[type].each do |k, v|
+        output format('%s %2f %d', "#{config[:scheme]}.#{type}.#{k}", v['value'].to_f, timestamp)
+      end
+    end
+  end
+
+  def original_output
+    data = acquire_stats
+    timestamp = Time.now.to_i
+    host = Socket.gethostname
+    uncommitted_messages = data['gauges']['org.graylog2.shared.journal.KafkaJournal.uncommittedMessages']['value']
+    unflushed_messages = data['gauges']['org.graylog2.shared.journal.KafkaJournal.unflushedMessages']['value']
+    output format('graylog.%s.graylog.kafkajournal.uncommittedMessages %d %d', host, uncommitted_messages, timestamp)
+    output format('graylog.%s.graylog.kafkajournal.unflushedMessages %d %d', host, unflushed_messages, timestamp)
+  end
+end

--- a/test/check-graylog-buffers_spec.rb
+++ b/test/check-graylog-buffers_spec.rb
@@ -1,0 +1,210 @@
+require_relative './spec_helper.rb'
+require_relative '../bin/check-graylog-buffers.rb'
+
+describe 'CheckGraylogBuffers', '#run' do
+  before(:all) do
+    CheckGraylogBuffers.class_variable_set(:@@autorun, nil)
+  end
+
+  it 'accepts config' do
+    args = %w(--username foo --password bar)
+    check = CheckGraylogBuffers.new(args)
+    expect(check.config[:password]).to eq 'bar'
+  end
+
+  it 'returns ok for pre 210' do
+    stub_request(:get, /system.*/)
+      .with(basic_auth: %w(foo bar))
+      .to_return(
+        status: 200,
+        headers: {
+          'Content-Type' => 'application/json'
+        },
+        body: {
+          'version' => '2.0.0+a1b2c3d'
+        }.to_json
+      ).then
+      .to_return(
+        status: 200,
+        headers: {
+          'Content-Type' => 'application/json'
+        },
+        body: {
+          'buffers' => {
+            'process' => {
+              'utilization_percent' => 50.12
+            }
+          }
+        }.to_json
+      )
+    args = %w(--username foo --password bar --host localhost --port 12900)
+
+    check = CheckGraylogBuffers.new(args)
+    expect(check).to receive(:ok).with('process buffer utilization is 50.12%').and_raise(SystemExit)
+    expect { check.run }.to raise_error(SystemExit)
+  end
+
+  it 'returns critical for pre 210' do
+    stub_request(:get, /system.*/)
+      .with(basic_auth: %w(foo bar))
+      .to_return(
+        status: 200,
+        headers: {
+          'Content-Type' => 'application/json'
+        },
+        body: {
+          'version' => '2.0.0+a1b2c3d'
+        }.to_json
+      ).then
+      .to_return(
+        status: 200,
+        headers: {
+          'Content-Type' => 'application/json'
+        },
+        body: {
+          'buffers' => {
+            'process' => {
+              'utilization_percent' => 99.99
+            }
+          }
+        }.to_json
+      )
+    args = %w(--username foo --password bar --host localhost --port 12900)
+
+    check = CheckGraylogBuffers.new(args)
+    expect(check).to receive(:critical).with('process buffer utilization is 99.99%, threshold is 90.00%').and_raise(SystemExit)
+    expect { check.run }.to raise_error(SystemExit)
+  end
+
+  it 'returns ok for post 210' do
+    stub_request(:any, /system.*/)
+      .with(basic_auth: %w(foo bar))
+      .to_return(
+        status: 200,
+        headers: {
+          'Content-Type' => 'application/json'
+        },
+        body: {
+          'version' => '2.2.0+a1b2c3d'
+        }.to_json
+      ).then
+      .to_return(
+        status: 200,
+        headers: {
+          'Content-Type' => 'application/json'
+        },
+        body: {
+          'total' => 6,
+          'metrics' => [
+            {
+              'full_name' => 'org.graylog2.buffers.input.usage',
+              'metric' => { 'value' => 2 },
+              'name' => 'usage',
+              'type' => 'gauge'
+            },
+            {
+              'full_name' => 'org.graylog2.buffers.input.size',
+              'metric' => { 'value' => 65_536 },
+              'name' => 'size',
+              'type' => 'gauge'
+            },
+            {
+              'full_name' => 'org.graylog2.buffers.process.usage',
+              'metric' => { 'value' => 4 },
+              'name' => 'usage',
+              'type' => 'gauge'
+            },
+            {
+              'full_name' => 'org.graylog2.buffers.process.size',
+              'metric' => { 'value' => 65_536 },
+              'name' => 'size',
+              'type' => 'gauge'
+            },
+            {
+              'full_name' => 'org.graylog2.buffers.output.usage',
+              'metric' => { 'value' => 8 },
+              'name' => 'usage',
+              'type' => 'gauge'
+            },
+            {
+              'full_name' => 'org.graylog2.buffers.output.size',
+              'metric' => { 'value' => 65_536 },
+              'name' => 'usage',
+              'type' => 'gauge'
+            }
+          ]
+        }.to_json
+      )
+    args = %w(--username foo --password bar --host localhost --port 12900)
+
+    check = CheckGraylogBuffers.new(args)
+    expect(check).to receive(:ok).with('buffer utilization is 0.00%/0.01%/0.01%').and_raise(SystemExit)
+    expect { check.run }.to raise_error(SystemExit)
+  end
+
+  it 'returns critical for post 210' do
+    stub_request(:any, /system.*/)
+      .with(basic_auth: %w(foo bar))
+      .to_return(
+        status: 200,
+        headers: {
+          'Content-Type' => 'application/json'
+        },
+        body: {
+          'version' => '2.2.0+a1b2c3d'
+        }.to_json
+      ).then
+      .to_return(
+        status: 200,
+        headers: {
+          'Content-Type' => 'application/json'
+        },
+        body: {
+          'total' => 6,
+          'metrics' => [
+            {
+              'full_name' => 'org.graylog2.buffers.input.usage',
+              'metric' => { 'value' => 2 },
+              'name' => 'usage',
+              'type' => 'gauge'
+            },
+            {
+              'full_name' => 'org.graylog2.buffers.input.size',
+              'metric' => { 'value' => 65_536 },
+              'name' => 'size',
+              'type' => 'gauge'
+            },
+            {
+              'full_name' => 'org.graylog2.buffers.process.usage',
+              'metric' => { 'value' => 4 },
+              'name' => 'usage',
+              'type' => 'gauge'
+            },
+            {
+              'full_name' => 'org.graylog2.buffers.process.size',
+              'metric' => { 'value' => 65_536 },
+              'name' => 'size',
+              'type' => 'gauge'
+            },
+            {
+              'full_name' => 'org.graylog2.buffers.output.usage',
+              'metric' => { 'value' => 65_000 },
+              'name' => 'usage',
+              'type' => 'gauge'
+            },
+            {
+              'full_name' => 'org.graylog2.buffers.output.size',
+              'metric' => { 'value' => 65_536 },
+              'name' => 'usage',
+              'type' => 'gauge'
+            }
+          ]
+        }.to_json
+      )
+    args = %w(--username foo --password bar --host localhost --port 12900)
+
+    check = CheckGraylogBuffers.new(args)
+    expect(check).to receive(:critical).with('output buffer exceeds 90.00%, buffer utilization is 0.00%/0.01%/99.18%').and_raise(SystemExit)
+    expect { check.run }.to raise_error(SystemExit)
+  end
+end

--- a/test/metrics-graylog_spec.rb
+++ b/test/metrics-graylog_spec.rb
@@ -53,6 +53,9 @@ describe 'MetricsGraylog', '#run' do
             'org.graylog2.shared.journal.KafkaJournal.unflushedMessages' => {
               'value' => 97.43
             },
+            'jvm.threads.deadlocks' => {
+              'value' => []
+            },
             'jvm.memory.heap.used' => {
               'value' => 885_385_736
             }

--- a/test/metrics-graylog_spec.rb
+++ b/test/metrics-graylog_spec.rb
@@ -1,0 +1,72 @@
+require_relative './spec_helper.rb'
+require_relative '../bin/metrics-graylog.rb'
+
+describe 'MetricsGraylog', '#run' do
+  before(:all) do
+    MetricsGraylog.class_variable_set(:@@autorun, nil)
+  end
+
+  it 'accepts config' do
+    args = %w(--username foo --password bar)
+    check = MetricsGraylog.new(args)
+    expect(check.config[:password]).to eq 'bar'
+  end
+
+  it 'returns original data' do
+    stub_request(:get, /system.*/)
+      .with(basic_auth: %w(foo bar))
+      .to_return(
+        status: 200,
+        headers: {
+          'Content-Type' => 'application/json'
+        },
+        body: {
+          'gauges' => {
+            'org.graylog2.shared.journal.KafkaJournal.uncommittedMessages' => {
+              'value' => 42
+            },
+            'org.graylog2.shared.journal.KafkaJournal.unflushedMessages' => {
+              'value' => 97.43
+            }
+          }
+        }.to_json
+      )
+    args = %w(--username foo --password bar --host localhost --port 12900)
+
+    check = MetricsGraylog.new(args)
+    expect { check.run }.to output(/uncommittedMessages 42.*unflushedMessages 97/m).to_stdout.and raise_error(SystemExit)
+  end
+
+  it 'returns all isata' do
+    stub_request(:get, /system.*/)
+      .with(basic_auth: %w(foo bar))
+      .to_return(
+        status: 200,
+        headers: {
+          'Content-Type' => 'application/json'
+        },
+        body: {
+          'gauges' => {
+            'org.graylog2.shared.journal.KafkaJournal.uncommittedMessages' => {
+              'value' => 42
+            },
+            'org.graylog2.shared.journal.KafkaJournal.unflushedMessages' => {
+              'value' => 97.43
+            },
+            'jvm.memory.heap.used' => {
+              'value' => 885_385_736
+            }
+          },
+          'counters' => {
+            'cluster-eventbus.executor-service.running' => {
+              'count' => 0
+            }
+          }
+        }.to_json
+      )
+    args = %w(--username foo --password bar --host localhost --port 12900 --all)
+
+    check = MetricsGraylog.new(args)
+    expect { check.run }.to output(/uncommittedMessages 42.*executor-service\.running 0/m).to_stdout.and raise_error(SystemExit)
+  end
+end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** 
No

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose
This PR ports the remaining python scripts to ruby, adding tests and additional functionality along the way.  The default execution intends to remain consistent to the original version.

New features
- `--apipath` for everything
- `--all` in metrics-graylog.rb pulls more data and changes naming to be similar to other plugins
- `--scheme` in metrics-graylog.rb allows one to change naming
- check-graylog-buffers.rb now understands new 2.10 and up buffer metrics and reports on them simialr to the old version

#### Known Compatibility Issues
None known.  One caveat is that for metrics-graylog.rb adding `--all` flag will switch naming.  I think this is clear from description, but please double check me on this.
