### PR TITLE
add check-graylog-streams script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
+- update readme to fix script names
 
+### Added
+- add check-graylog-streams.rb to check and alert on paused streams
 
 ## [1.0.0] - 2017-03-15
 This release drops support for Ruby 1.9.3 and converts `check-graylog-buffers` and `metrics-graylog`

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@
 This plugin provides availability monitoring and metrics collection for the [Graylog](https://www.graylog.org/) log management system.
 
 ## Files
+ * bin/check-graylog-buffers.rb
+ * bin/check-graylog-streams.rb
  * bin/check-graylog2-alive.rb
- * bin/check-graylog-buffers.py
- * bin/metrics-graylog.py
+ * bin/metrics-graylog.rb
 
 ## Usage
 
@@ -22,5 +23,6 @@ This plugin provides availability monitoring and metrics collection for the [Gra
 
 ## Notes
 - If you want a limited access user for monitoring purposes please see the [Graylog FAQ](http://docs.graylog.org/en/latest/pages/faq.html#how-can-i-create-a-restricted-user-to-check-internal-graylog-metrics-in-my-monitoring-system+)
+  - A limited user must also have the "streams:read" permission on their role in order to use the check-graylog-streams.rb check
 - Users may further obfuscate their credentials by creating an [Access Token](http://docs.graylog.org/en/latest/pages/configuration/rest_api.html?highlight=access%20tokens#creating-and-using-access-token) to use instead of their normal login credentials.
   - Note that only an admin may create a token by default.  If you want to have a dedicated monitoring user with an access token you will need to create them as a Admin user, create the token, then change the user to the monitoring specific role. You can change the default behavior by granting `users:tokencreate`, `users:tokenlist`, and `users:tokenremove` to a role and adding that role to the monitoring user.

--- a/bin/check-graylog-streams.rb
+++ b/bin/check-graylog-streams.rb
@@ -21,7 +21,6 @@
 #   Released under the same terms as Sensu (the MIT license); see LICENSE
 #   for details.
 
-require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
 require 'rest-client'
 require 'json'

--- a/bin/check-graylog-streams.rb
+++ b/bin/check-graylog-streams.rb
@@ -1,0 +1,92 @@
+#!/usr/bin/env ruby
+#
+# Checks Graylog paused streams
+# ===
+#
+# DESCRIPTION:
+#   This plugin checks Graylog for any 'paused' streams.
+#
+# OUTPUT:
+#   plain-text
+#
+# PLATFORMS:
+#   all
+#
+# DEPENDENCIES:
+#   A graylog user with streams:read permission (admin or role perm)
+#
+# LICENSE:
+#   Seandy Wibowo <swibowo@sugarcrm.com>
+#   nathan hruby <nhruby@sugarcrm.com>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+
+require 'rubygems' if RUBY_VERSION < '1.9.0'
+require 'sensu-plugin/check/cli'
+require 'rest-client'
+require 'json'
+
+class CheckGraylogStreams < Sensu::Plugin::Check::CLI
+  option :username,
+         short:       '-u',
+         long:        '--username USERNAME',
+         description: 'Graylog Username',
+         required:    true
+
+  option :password,
+         short:       '-p',
+         long:        '--password PASSWORD',
+         description: 'Graylog Password',
+         required:    true
+
+  option :host,
+         short:       '-h',
+         long:        '--host GRAYLOG_HOST',
+         description: 'Graylog host to query',
+         default:     'localhost'
+
+  option :port,
+         short:       '-P',
+         long:        '--port GRAYLOG_PORT',
+         description: 'Graylog port to query',
+         default:     12_900
+
+  option :apipath,
+         short:       '-a',
+         long:        '--apipath /api',
+         description: 'Graylog API path prefix',
+         default:     ''
+
+  def graylog_streams
+    resource = RestClient::Resource.new(
+      "http://#{config[:host]}:#{config[:port]}#{config[:apipath]}/streams",
+      user: config[:username],
+      password: config[:password],
+      timeout: 10
+    )
+    JSON.parse(resource.get, symbolize_names: true)
+
+  rescue RestClient::RequestTimeout
+    unknown 'Connection timeout'
+  rescue SocketError
+    unknown 'Network unavailable'
+  rescue RestClient::Unauthorized
+    unknown 'Missing or incorrect API credentials'
+  rescue JSON::ParserError
+    unknown 'API returned invalid JSON'
+  end
+
+  def run
+    streams = graylog_streams
+    disabled_streams = streams[:streams].select { |s| (s[:disabled] == true) }
+
+    if disabled_streams.count > 0
+      streams_desc = []
+      disabled_streams.each { |v| streams_desc.push(v[:title]) }
+
+      critical("Streams currently paused/disabled: #{streams_desc.join(', ')}")
+    else
+      ok('No streams are paused')
+    end
+  end
+end

--- a/test/check-graylog-streams_spec.rb
+++ b/test/check-graylog-streams_spec.rb
@@ -1,0 +1,76 @@
+require_relative './spec_helper.rb'
+require_relative '../bin/check-graylog-streams.rb'
+
+describe 'CheckGraylogStreams', '#run' do
+  before(:all) do
+    CheckGraylogStreams.class_variable_set(:@@autorun, nil)
+  end
+
+  it 'accepts config' do
+    args = %w(--username foo --password bar)
+    check = CheckGraylogStreams.new(args)
+    expect(check.config[:password]).to eq 'bar'
+  end
+
+  it 'returns ok' do
+    stub_request(:get, 'http://localhost:12900/streams')
+      .with(basic_auth: %w(foo bar))
+      .to_return(
+        status: 200,
+        headers: {
+          'Content-Type' => 'application/json'
+        },
+        body: {
+          'total' => 2,
+          'streams' => [
+            {
+              'id' => '000000000000000000000001',
+              'title' => 'All messages',
+              'disabled' => false
+            },
+            {
+              'id' => 'abc123def456deadbeef',
+              'title' => 'test stream',
+              'disabled' => false
+            }
+          ]
+        }.to_json
+      )
+    args = %w(--username foo --password bar --host localhost --port 12900)
+
+    check = CheckGraylogStreams.new(args)
+    expect(check).to receive(:ok).with('No streams are paused').and_raise(SystemExit)
+    expect { check.run }.to raise_error(SystemExit)
+  end
+
+  it 'returns critical' do
+    stub_request(:get, 'http://localhost:12900/streams')
+      .with(basic_auth: %w(foo bar))
+      .to_return(
+        status: 200,
+        headers: {
+          'Content-Type' => 'application/json'
+        },
+        body: {
+          'total' => 2,
+          'streams' => [
+            {
+              'id' => '000000000000000000000001',
+              'title' => 'All messages',
+              'disabled' => false
+            },
+            {
+              'id' => 'abc123def456deadbeef',
+              'title' => 'test stream',
+              'disabled' => true
+            }
+          ]
+        }.to_json
+      )
+    args = %w(--username foo --password bar --host localhost --port 12900)
+
+    check = CheckGraylogStreams.new(args)
+    expect(check).to receive(:critical).with('Streams currently paused/disabled: test stream').and_raise(SystemExit)
+    expect { check.run }.to raise_error(SystemExit)
+  end
+end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**  No

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose
This adds an additional check called "check-graylog-streams.rb" that looks for and alerts on paused streams.  Graylog will automatically pause a stream when the processing time for it gets too long as a defense measure (long GC, expensive criteria, etc..).   

Since streams are applied only at event index time, there's no way to retroactively apply them after the stream is unpaused, so quick notification and repair is important.

#### Known Compatibility Issues
None known, this is new script.
