### PR TITLE
set a sane default for `check-graylog2-alive.rb`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Fixed
+- check-graylog2-alive.rb: changed the default of `--apipath` to `/api` from an empty string. If you specified this there is no change necessary. (@majormoses)
 
 ## [1.3.0] - 2018-02-16
 ### Added

--- a/bin/check-graylog2-alive.rb
+++ b/bin/check-graylog2-alive.rb
@@ -79,7 +79,7 @@ class CheckGraylog2Alive < Sensu::Plugin::Check::CLI
          description: 'Graylog API path prefix',
          short: '-a',
          long: '--apipath /api',
-         default: ''
+         default: '/api'
 
   def run
     res = vhost_alive?

--- a/test/check-graylog2-alive_spec.rb
+++ b/test/check-graylog2-alive_spec.rb
@@ -13,7 +13,7 @@ describe 'CheckGraylog2Alive', '#run' do
   end
 
   it 'returns ok' do
-    stub_request(:get, 'http://localhost:12900/system')
+    stub_request(:get, 'http://localhost:12900/api/system')
       .with(basic_auth: %w(foo bar))
       .to_return(
         status: 200,
@@ -34,7 +34,7 @@ describe 'CheckGraylog2Alive', '#run' do
   end
 
   it 'returns critical' do
-    stub_request(:get, 'http://localhost:12900/system')
+    stub_request(:get, 'http://localhost:12900/api/system')
       .with(basic_auth: %w(foo bar))
       .to_return(
         status: 200,
@@ -55,7 +55,7 @@ describe 'CheckGraylog2Alive', '#run' do
   end
 
   it 'uses apipath' do
-    stub_request(:get, 'http://localhost:12900/test/system')
+    stub_request(:get, 'http://localhost:12900/api/system')
       .with(basic_auth: %w(foo bar))
       .to_return(
         status: 200,
@@ -68,7 +68,7 @@ describe 'CheckGraylog2Alive', '#run' do
           'lb_status' => 'alive'
         }.to_json
       )
-    args = %w(--username foo --password bar --host localhost --port 12900 --apipath /test)
+    args = %w(--username foo --password bar --host localhost --port 12900 --apipath /api)
 
     check = CheckGraylog2Alive.new(args)
     expect(check).to receive(:ok).with('Graylog2 server is: running/true/alive').and_raise(SystemExit)


### PR DESCRIPTION
From my research it looks like this default makes sense since 2.0, this may have changed from 1.x but I cant any docs on the old endpoint.

Before:
```
$ bundle exec ./bin/check-graylog2-alive.rb --protocol https --host $HOST.$DOMAIN.$TLD --username $USERNAME --password $(cat creds) --port 443
CheckGraylog2Alive UNKNOWN: 784: unexpected token at '<!DOCTYPE html>
<html>
  <head>
    <meta http-equiv="X-UA-Compatible" content="IE=edge">
    <meta name="robots" content="noindex, nofollow">
    <meta charset="UTF-8">
    <title>Graylog Web Interface</title>
    <link rel="shortcut icon" href="/assets/favicon.png">

  </head>
  <body>
    <script src="/config.js"></script>
    <script src="/assets/vendor.js"></script>

    <script src="/assets/polyfill.35e28e4da7743596569a.js"></script>

    <script src="/assets/plugin/org.graylog.plugins.pipelineprocessor.ProcessorPlugin/plugin.org.graylog.plugins.pipelineprocessor.PipelineProcessorPlugin.0cbe11128085ed745b77.js"></script>

    <script src="/assets/plugin/org.graylog.plugins.map.MapWidgetPlugin/plugin.org.graylog.plugins.map.MapWidgetPlugin.5011f2ebff35ef956f1b.js"></script>

    <script src="/assets/plugin/org.graylog.plugins.enterprise_integration.EnterpriseIntegrationPlugin/plugin.org.graylog.plugins.enterprise_integration.EnterpriseIntegrationPlugin.3e5ff59c400f972516bd.js"></script>

    <script src="/assets/plugin/org.graylog.plugins.collector.CollectorPlugin/plugin.org.graylog.plugins.collector.CollectorPlugin.13edb0af11e27a17b001.js"></script>

    <script src="/assets/app.35e28e4da7743596569a.js"></script>

  </body>
</html>
'
```

After:
```
$ bundle exec ./bin/check-graylog2-alive.rb --protocol https --host $HOST.$DOMAIN.$TLD --username $USERNAME --password $(cat creds) --port 443
CheckGraylog2Alive OK: Graylog2 server is: running/true/alive
```

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

fixes #10 

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [ ] Existing tests pass

#### Purpose
Set a sane default.

#### Known Compatibility Issues
none