### PR TITLE
Add compatibility with graylog 2.5+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
-### Fixed
+### Added
 - check-graylog-buffers.rb: added CSRF protection required by graylog 2.5+. (@themysteriousx)
 
 ## [1.3.1] - 2018-02-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Fixed
+- check-graylog-buffers.rb: added CSRF protection required by graylog 2.5+. (@themysteriousx)
 
 ## [1.3.1] - 2018-02-20
 ### Fixed

--- a/bin/check-graylog-buffers.rb
+++ b/bin/check-graylog-buffers.rb
@@ -114,7 +114,7 @@ class CheckGraylogBuffers < Sensu::Plugin::Check::CLI
     if !postdata
       JSON.parse(resource.get)
     else
-      JSON.parse(resource.post(postdata.to_json, content_type: :json, accept: :json))
+      JSON.parse(resource.post(postdata.to_json, content_type: :json, accept: :json, x_requested_by: SecureRandom.base64(32)))
     end
   rescue Errno::ECONNREFUSED => e
     critical e.message

--- a/bin/check-graylog-buffers.rb
+++ b/bin/check-graylog-buffers.rb
@@ -33,10 +33,13 @@
 #
 
 require 'sensu-plugin/check/cli'
+require 'sensu-plugin/utils'
 require 'json'
 require 'rest-client'
 
 class CheckGraylogBuffers < Sensu::Plugin::Check::CLI
+  include Sensu::Plugin::Utils
+
   option :protocol,
          description: 'Protocol for connecting to Graylog',
          long: '--protocol PROTOCOL',
@@ -114,7 +117,12 @@ class CheckGraylogBuffers < Sensu::Plugin::Check::CLI
     if !postdata
       JSON.parse(resource.get)
     else
-      JSON.parse(resource.post(postdata.to_json, content_type: :json, accept: :json, x_requested_by: SecureRandom.base64(32)))
+      JSON.parse(resource.post(
+        postdata.to_json,
+        content_type: :json,
+        accept: :json,
+        x_requested_by: "sensu-client on #{settings['client']['name']}"
+      ))
     end
   rescue Errno::ECONNREFUSED => e
     critical e.message

--- a/bin/check-graylog-buffers.rb
+++ b/bin/check-graylog-buffers.rb
@@ -117,12 +117,14 @@ class CheckGraylogBuffers < Sensu::Plugin::Check::CLI
     if !postdata
       JSON.parse(resource.get)
     else
-      JSON.parse(resource.post(
-        postdata.to_json,
-        content_type: :json,
-        accept: :json,
-        x_requested_by: "sensu-client on #{settings['client']['name']}"
-      ))
+      JSON.parse(
+        resource.post(
+          postdata.to_json,
+          content_type: :json,
+          accept: :json,
+          x_requested_by: "sensu-client on #{settings['client']['name']}"
+        )
+      )
     end
   rescue Errno::ECONNREFUSED => e
     critical e.message

--- a/test/check-graylog-buffers_spec.rb
+++ b/test/check-graylog-buffers_spec.rb
@@ -40,7 +40,7 @@ describe 'CheckGraylogBuffers', '#run' do
     args = %w(--username foo --password bar --host localhost --port 12900)
 
     check = CheckGraylogBuffers.new(args)
-    check.instance_variable_set('@settings', {'client' => {'name' => 'sensu.example.org'}})
+    check.instance_variable_set('@settings', 'client' => { 'name' => 'sensu.example.org' })
     expect(check).to receive(:ok).with('process buffer utilization is 50.12%').and_raise(SystemExit)
     expect { check.run }.to raise_error(SystemExit)
   end
@@ -73,7 +73,7 @@ describe 'CheckGraylogBuffers', '#run' do
     args = %w(--username foo --password bar --host localhost --port 12900)
 
     check = CheckGraylogBuffers.new(args)
-    check.instance_variable_set('@settings', {'client' => {'name' => 'sensu.example.org'}})
+    check.instance_variable_set('@settings', 'client' => { 'name' => 'sensu.example.org' })
     expect(check).to receive(:critical).with('process buffer utilization is 99.99%, threshold is 90.00%').and_raise(SystemExit)
     expect { check.run }.to raise_error(SystemExit)
   end
@@ -140,7 +140,7 @@ describe 'CheckGraylogBuffers', '#run' do
     args = %w(--username foo --password bar --host localhost --port 12900)
 
     check = CheckGraylogBuffers.new(args)
-    check.instance_variable_set('@settings', {'client' => {'name' => 'sensu.example.org'}})
+    check.instance_variable_set('@settings', 'client' => { 'name' => 'sensu.example.org' })
     expect(check).to receive(:ok).with('buffer utilization is 0.00%/0.01%/0.01%').and_raise(SystemExit)
     expect { check.run }.to raise_error(SystemExit)
   end
@@ -207,7 +207,7 @@ describe 'CheckGraylogBuffers', '#run' do
     args = %w(--username foo --password bar --host localhost --port 12900)
 
     check = CheckGraylogBuffers.new(args)
-    check.instance_variable_set('@settings', {'client' => {'name' => 'sensu.example.org'}})
+    check.instance_variable_set('@settings', 'client' => { 'name' => 'sensu.example.org' })
     expect(check).to receive(:critical).with('output buffer exceeds 90.00%, buffer utilization is 0.00%/0.01%/99.18%').and_raise(SystemExit)
     expect { check.run }.to raise_error(SystemExit)
   end

--- a/test/check-graylog-buffers_spec.rb
+++ b/test/check-graylog-buffers_spec.rb
@@ -40,6 +40,7 @@ describe 'CheckGraylogBuffers', '#run' do
     args = %w(--username foo --password bar --host localhost --port 12900)
 
     check = CheckGraylogBuffers.new(args)
+    check.instance_variable_set('@settings', {'client' => {'name' => 'sensu.example.org'}})
     expect(check).to receive(:ok).with('process buffer utilization is 50.12%').and_raise(SystemExit)
     expect { check.run }.to raise_error(SystemExit)
   end
@@ -72,6 +73,7 @@ describe 'CheckGraylogBuffers', '#run' do
     args = %w(--username foo --password bar --host localhost --port 12900)
 
     check = CheckGraylogBuffers.new(args)
+    check.instance_variable_set('@settings', {'client' => {'name' => 'sensu.example.org'}})
     expect(check).to receive(:critical).with('process buffer utilization is 99.99%, threshold is 90.00%').and_raise(SystemExit)
     expect { check.run }.to raise_error(SystemExit)
   end
@@ -138,6 +140,7 @@ describe 'CheckGraylogBuffers', '#run' do
     args = %w(--username foo --password bar --host localhost --port 12900)
 
     check = CheckGraylogBuffers.new(args)
+    check.instance_variable_set('@settings', {'client' => {'name' => 'sensu.example.org'}})
     expect(check).to receive(:ok).with('buffer utilization is 0.00%/0.01%/0.01%').and_raise(SystemExit)
     expect { check.run }.to raise_error(SystemExit)
   end
@@ -204,6 +207,7 @@ describe 'CheckGraylogBuffers', '#run' do
     args = %w(--username foo --password bar --host localhost --port 12900)
 
     check = CheckGraylogBuffers.new(args)
+    check.instance_variable_set('@settings', {'client' => {'name' => 'sensu.example.org'}})
     expect(check).to receive(:critical).with('output buffer exceeds 90.00%, buffer utilization is 0.00%/0.01%/99.18%').and_raise(SystemExit)
     expect { check.run }.to raise_error(SystemExit)
   end


### PR DESCRIPTION
As per http://docs.graylog.org/en/2.5/pages/configuration/rest_api.html, graylog 2.5+ needs a header called `X-Requested-By` to provide CSRF protection.

This is a tiny change to add that header on to the POST request in `check-graylog-buffers.rb`, which fails under graylog 2.5+.

This change is backwards compatible - graylog 2.4 and below will just ignore the extra header.

I'm not a ruby programmer, so please feel free to correct the syntax or suggest a better way. This works for me.

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
Bugfix

#### Known Compatibility Issues
None