### PR TITLE
Updated buffers check with header.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Fixed
+- check-graylog2-buffers.rb: added the header "X-Requested-By" to the post request as per: http://docs.graylog.org/en/2.5/pages/upgrade/graylog-2.5.html#protecting-against-csrf-http-header-required (@sestary)
 
 ## [1.3.1] - 2018-02-20
 ### Fixed

--- a/bin/check-graylog-buffers.rb
+++ b/bin/check-graylog-buffers.rb
@@ -114,7 +114,7 @@ class CheckGraylogBuffers < Sensu::Plugin::Check::CLI
     if !postdata
       JSON.parse(resource.get)
     else
-      JSON.parse(resource.post(postdata.to_json, content_type: :json, accept: :json))
+      JSON.parse(resource.post(postdata.to_json, content_type: :json, accept: :json, :'X-Requested-By' => 'Sensu Buffers Check'))
     end
   rescue Errno::ECONNREFUSED => e
     critical e.message


### PR DESCRIPTION
## Pull Request Checklist

There is no existing issue, but on Graylog 2.5+ this buffers check will fail with "CheckGraylogBuffers UNKNOWN: 400 Bad Request"

#### Purpose

To make the check work with Graylog 2.5+

#### Known Compatibility Issues

None
