### PR TITLE
Make metrics compatible with Graylog 3

### DIFF
--- a/bin/metrics-graylog.rb
+++ b/bin/metrics-graylog.rb
@@ -112,7 +112,7 @@ class MetricsGraylog < Sensu::Plugin::Metric::CLI::Graphite
       password: config[:password],
       verify_ssl: !config[:insecure]
     )
-    JSON.parse(resource.get)
+    ::JSON.parse(resource.get)
   rescue Errno::ECONNREFUSED => e
     critical e.message
   end


### PR DESCRIPTION
The current ruby script does not work properly with Graylog 3 and gives an error: `Sensu::Plugin::Metric::CLI:: JSON:Class`
Adding `::` before the JSON.parse makes it work properly

## Pull Request Checklist

**Is this in reference to an existing issue?**

No

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets
Not needed

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
Make metrics compatible with Graylog 3+

#### Known Compatibility Issues
None that I have seen with Graylog 3.1.2